### PR TITLE
Reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ colored = "2"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 shellwords = "1"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Hi! I added a couple of changes for the release profile (when running `cargo build --release` to reduce the binary size from 6.4mb to 2mb.
Source: https://github.com/johnthagen/min-sized-rust